### PR TITLE
Add investment source tracking and PDF reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "financial-monitor",
       "version": "0.1.0",
       "dependencies": {
-        "@headlessui/react": "^2.2.9",
-        "@heroicons/react": "^2.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "recharts": "^2.10.3"
@@ -859,33 +857,6 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
-    },
-    "node_modules/@headlessui/react": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.9.tgz",
-      "integrity": "sha512-Mb+Un58gwBn0/yWZfyrCh0TJyurtT+dETj7YHleylHk5od3dv2XqETPGWMyQ5/7sYN7oWdyM1u9MvC0OC8UmzQ==",
-      "dependencies": {
-        "@floating-ui/react": "^0.26.16",
-        "@react-aria/focus": "^3.20.2",
-        "@react-aria/interactions": "^3.25.0",
-        "@tanstack/react-virtual": "^3.13.9",
-        "use-sync-external-store": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/@heroicons/react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
-      "peerDependencies": {
-        "react": ">= 16 || ^19.0.0-rc"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@headlessui/react": "^2.2.9",
-    "@heroicons/react": "^2.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "recharts": "^2.10.3"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,8 @@ import { Historico } from "./components/Historico.jsx";
 import { KPICard } from "./components/KPICard.jsx";
 import { Tabs } from "./components/Tab.jsx";
 import { ActionButton } from "./components/ActionButton.jsx";
-import { demoBanks, demoCreatedAt, demoEntries } from "./data/demoEntries.js";
+import { PersonalInfoModal } from "./components/PersonalInfoModal.jsx";
+import { demoBanks, demoCreatedAt, demoEntries, demoSources } from "./data/demoEntries.js";
 import {
   ArrowDownTrayIcon,
   ArrowUpTrayIcon,
@@ -14,7 +15,9 @@ import {
   ChartBarIcon,
   TableCellsIcon,
   PlusIcon,
-} from '@heroicons/react/24/outline';
+  DocumentArrowDownIcon,
+  UserCircleIcon,
+} from "./components/icons.jsx";
 import { useLocalStorageState } from "./hooks/useLocalStorageState.js";
 import {
   download,
@@ -35,10 +38,14 @@ import {
   withId,
 } from "./utils/entries.js";
 import { DEFAULT_BANKS, ensureBankInLibrary } from "./config/banks.js";
+import { DEFAULT_SOURCES, ensureSourceInLibrary } from "./config/sources.js";
+import { createPdfReport } from "./utils/pdf.js";
 
 const STORAGE_SEED = {
   entries: [],
   banks: DEFAULT_BANKS,
+  sources: DEFAULT_SOURCES,
+  personalInfo: {},
   createdAt: new Date().toISOString(),
 };
 
@@ -46,11 +53,14 @@ export default function App() {
   const [store, setStore] = useLocalStorageState(LS_KEY, STORAGE_SEED);
   const entries = Array.isArray(store.entries) ? store.entries : [];
   const banks = Array.isArray(store.banks) && store.banks.length ? store.banks : DEFAULT_BANKS;
+  const sources = Array.isArray(store.sources) && store.sources.length ? store.sources : DEFAULT_SOURCES;
+  const personalInfo = store.personalInfo || {};
   const createdAt = store.createdAt ?? STORAGE_SEED.createdAt;
 
   const [tab, setTab] = useState("dashboard");
   const [drafts, setDrafts] = useState(() => [createDraftEntry()]);
   const fileRef = useRef(null);
+  const [personalModalOpen, setPersonalModalOpen] = useState(false);
 
   const setEntries = (updater) => {
     setStore((prev) => {
@@ -58,13 +68,19 @@ export default function App() {
       const candidateEntries = typeof updater === "function" ? updater(currentEntries) : updater;
       const nextEntries = Array.isArray(candidateEntries) ? candidateEntries : [];
       const currentBanks = Array.isArray(prev.banks) && prev.banks.length ? prev.banks : DEFAULT_BANKS;
+      const currentSources = Array.isArray(prev.sources) && prev.sources.length ? prev.sources : DEFAULT_SOURCES;
       const mergedBanks = mergeBanksFromEntries(nextEntries, currentBanks);
-      return { ...prev, entries: nextEntries, banks: mergedBanks };
+      const mergedSources = mergeSourcesFromEntries(nextEntries, currentSources);
+      return { ...prev, entries: nextEntries, banks: mergedBanks, sources: mergedSources };
     });
   };
 
   const setCreatedAt = (value) => {
     setStore((prev) => ({ ...prev, createdAt: value }));
+  };
+
+  const setPersonalInfo = (value) => {
+    setStore((prev) => ({ ...prev, personalInfo: { ...value } }));
   };
 
   useEffect(() => {
@@ -73,6 +89,8 @@ export default function App() {
       setStore({
         entries: normalized,
         banks: mergeBanksFromEntries(normalized, DEFAULT_BANKS),
+        sources: mergeSourcesFromEntries(normalized, DEFAULT_SOURCES),
+        personalInfo: {},
         createdAt: new Date().toISOString(),
       });
     }
@@ -164,6 +182,27 @@ export default function App() {
   }, [monthly, monthlyLookup]);
 
   const totals = useMemo(() => computeTotals(derivedEntries), [derivedEntries]);
+
+  const sourceSummary = useMemo(() => {
+    const map = new Map();
+    for (const entry of derivedEntries) {
+      const key = (entry.source || "Outros").trim() || "Outros";
+      const current = map.get(key) || { name: key, invested: 0, total: 0 };
+      current.invested += toNumber(entry.invested);
+      current.total += toNumber(entry.computedTotal ?? entry.invested ?? 0);
+      map.set(key, current);
+    }
+    const totalInvested = Array.from(map.values()).reduce((acc, item) => acc + item.invested, 0);
+    return Array.from(map.values())
+      .map((item) => ({
+        name: item.name,
+        invested: item.invested,
+        total: item.total,
+        percentage: totalInvested ? Math.round((item.invested / totalInvested) * 100) : 0,
+      }))
+      .sort((a, b) => b.invested - a.invested);
+  }, [derivedEntries]);
+
   const lastMonth = timeline.at(-1);
 
   function handleSubmitDrafts(rows) {
@@ -172,6 +211,7 @@ export default function App() {
       .map((row) => ({
         id: makeId(),
         bank: row.bank.trim(),
+        source: row.source?.trim() || "",
         date: row.date,
         invested: toNumber(row.invested),
         inAccount: toNumber(row.inAccount),
@@ -192,6 +232,8 @@ export default function App() {
       created_at: createdAt,
       exported_at: new Date().toISOString(),
       banks,
+      sources,
+      personal_info: personalInfo,
       inputs: [
         {
           summary,
@@ -212,6 +254,13 @@ export default function App() {
       banks: [
         { name: "Banco Exemplo", color: "#2563EB", icon: "🏦" },
       ],
+      sources: [
+        { name: "Salário", color: "#0EA5E9", icon: "💼" },
+      ],
+      personal_info: {
+        fullName: "Nome do Investidor",
+        email: "investidor@email.com",
+      },
       inputs: [
         {
           summary: {
@@ -223,6 +272,7 @@ export default function App() {
           entries: [
             {
               bank: "Banco Exemplo",
+              source: "Salário",
               date: "2025-01-15",
               inAccount: 0,
               invested: 1000,
@@ -246,15 +296,19 @@ export default function App() {
             ...prev,
             entries: normalized,
             banks: mergeBanksFromEntries(normalized, prev.banks || DEFAULT_BANKS),
+            sources: mergeSourcesFromEntries(normalized, prev.sources || DEFAULT_SOURCES),
           }));
         } else if (data && Array.isArray(data.inputs)) {
           const inputEntries = data.inputs.flatMap((section) => section.entries || []);
           const normalized = inputEntries.map(withId);
           const incomingBanks = Array.isArray(data.banks) && data.banks.length ? data.banks : banks;
+          const incomingSources = Array.isArray(data.sources) && data.sources.length ? data.sources : sources;
           const created = data.created_at || createdAt || new Date().toISOString();
           setStore({
             entries: normalized,
             banks: mergeBanksFromEntries(normalized, incomingBanks),
+            sources: mergeSourcesFromEntries(normalized, incomingSources),
+            personalInfo: data.personal_info || personalInfo,
             createdAt: created,
           });
         } else if (data && Array.isArray(data.entries)) {
@@ -263,6 +317,7 @@ export default function App() {
             ...prev,
             entries: normalized,
             banks: mergeBanksFromEntries(normalized, prev.banks || DEFAULT_BANKS),
+            sources: mergeSourcesFromEntries(normalized, prev.sources || DEFAULT_SOURCES),
           }));
         } else {
           window.alert(
@@ -282,49 +337,73 @@ export default function App() {
       setStore({
         entries: normalized,
         banks: mergeBanksFromEntries(normalized, demoBanks),
+        sources: mergeSourcesFromEntries(normalized, demoSources),
+        personalInfo,
         createdAt: demoCreatedAt,
       });
     }
   }
 
+  function handleGeneratePdf() {
+    createPdfReport({
+      personalInfo,
+      totals,
+      sources: sourceSummary.map((source) => ({
+        name: source.name,
+        total: source.invested,
+        percentage: source.percentage,
+      })),
+      entries: entriesWithIds,
+      exportedAt: new Date(),
+    });
+  }
+
   return (
     <div className="min-h-screen w-full bg-slate-50 p-6 text-slate-800">
       <div className="mx-auto max-w-6xl">
-        <header className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="space-y-2">
-            <h1 className="text-2xl font-bold">Monitor de Investimentos – Leo</h1>
-            <p className="text-sm text-slate-600">
-              Adicione lançamentos, visualize o histórico por mês e gere gráficos. Seus dados ficam apenas no seu navegador
-              (localStorage).
-            </p>
-          </div>
-          <div className="flex items-center justify-end gap-4">
-            <div className="flex items-center gap-2">
-              <ActionButton icon={ArrowDownTrayIcon} onClick={exportJson}>
-                Exportar
-              </ActionButton>
-              <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium shadow-sm transition hover:border-slate-300 hover:text-slate-900">
-                <ArrowUpTrayIcon className="h-5 w-5" />
-                Importar
-                <input
-                  ref={fileRef}
-                  type="file"
-                  accept="application/json"
-                  className="hidden"
-                  onChange={(e) => e.target.files && e.target.files[0] && importJsonFile(e.target.files[0])}
-                />
-              </label>
-              <ActionButton icon={DocumentIcon} onClick={downloadTemplate}>
-                Template
-              </ActionButton>
-              <ActionButton
-                icon={TrashIcon}
-                onClick={() => {
-                  if (window.confirm("Tem certeza que deseja apagar todos os lançamentos?")) setEntries([]);
-                }}
-              >
-                Limpar
-              </ActionButton>
+        <header className="mb-6 space-y-4">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-2">
+              <h1 className="text-2xl font-bold">Monitor de Investimentos – Leo</h1>
+              <p className="text-sm text-slate-600">
+                Adicione lançamentos, visualize o histórico por mês e gere gráficos. Seus dados ficam apenas no seu navegador
+                (localStorage).
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-end">
+              <div className="flex flex-wrap items-center gap-2">
+                <ActionButton icon={ArrowDownTrayIcon} onClick={exportJson}>
+                  Exportar
+                </ActionButton>
+                <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium shadow-sm transition hover:border-slate-300 hover:text-slate-900">
+                  <ArrowUpTrayIcon className="h-5 w-5" />
+                  Importar
+                  <input
+                    ref={fileRef}
+                    type="file"
+                    accept="application/json"
+                    className="hidden"
+                    onChange={(e) => e.target.files && e.target.files[0] && importJsonFile(e.target.files[0])}
+                  />
+                </label>
+                <ActionButton icon={DocumentIcon} onClick={downloadTemplate}>
+                  Template
+                </ActionButton>
+                <ActionButton icon={DocumentArrowDownIcon} onClick={handleGeneratePdf}>
+                  Relatório PDF
+                </ActionButton>
+                <ActionButton icon={UserCircleIcon} onClick={() => setPersonalModalOpen(true)}>
+                  Dados pessoais
+                </ActionButton>
+                <ActionButton
+                  icon={TrashIcon}
+                  onClick={() => {
+                    if (window.confirm("Tem certeza que deseja apagar todos os lançamentos?")) setEntries([]);
+                  }}
+                >
+                  Limpar
+                </ActionButton>
+              </div>
             </div>
           </div>
           <Tabs
@@ -339,7 +418,12 @@ export default function App() {
         </header>
 
         <section className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
-          <KPICard title="Total Investido" value={fmtBRL(totals.total_invested)} subtitle="Soma atual de 'Valor em Investimentos'" />
+          <KPICard
+            title="Total Investido"
+            value={fmtBRL(totals.total_invested)}
+            subtitle="Soma atual de 'Valor em Investimentos'"
+            hoverDetails={sourceSummary}
+          />
           <KPICard
             title="Investido último mês"
             value={fmtBRL(lastMonth?.invested ?? 0)}
@@ -379,7 +463,7 @@ export default function App() {
           </button>
         </section>
 
-        {tab === "dashboard" && <Dashboard monthly={timeline} />}
+        {tab === "dashboard" && <Dashboard monthly={timeline} sourceSummary={sourceSummary} sources={sources} />}
 
         {tab === "historico" && (
           <Historico
@@ -387,11 +471,12 @@ export default function App() {
             computedEntries={derivedEntries}
             setEntries={setEntries}
             banks={banks}
+            sources={sources}
           />
         )}
 
         {tab === "entrada" && (
-          <Entrada drafts={drafts} setDrafts={setDrafts} onSubmit={handleSubmitDrafts} banks={banks} />
+          <Entrada drafts={drafts} setDrafts={setDrafts} onSubmit={handleSubmitDrafts} banks={banks} sources={sources} />
         )}
 
         <footer className="mt-10 text-center text-xs text-slate-500">
@@ -401,6 +486,12 @@ export default function App() {
           </p>
         </footer>
       </div>
+      <PersonalInfoModal
+        open={personalModalOpen}
+        onClose={() => setPersonalModalOpen(false)}
+        initialValue={personalInfo}
+        onSave={setPersonalInfo}
+      />
     </div>
   );
 }
@@ -416,6 +507,14 @@ function mergeBanksFromEntries(entries, baseBanks = DEFAULT_BANKS) {
   let next = Array.isArray(baseBanks) ? [...baseBanks] : [...DEFAULT_BANKS];
   for (const entry of entries) {
     next = ensureBankInLibrary(entry.bank, next);
+  }
+  return next;
+}
+
+function mergeSourcesFromEntries(entries, baseSources = DEFAULT_SOURCES) {
+  let next = Array.isArray(baseSources) ? [...baseSources] : [...DEFAULT_SOURCES];
+  for (const entry of entries) {
+    next = ensureSourceInLibrary(entry.source, next);
   }
   return next;
 }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -4,17 +4,21 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  Cell,
   Legend,
   Line,
   LineChart,
+  Pie,
+  PieChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
 import { fmtBRL } from "../utils/formatters.js";
+import { resolveSourceVisual } from "../config/sources.js";
 
-export function Dashboard({ monthly }) {
+export function Dashboard({ monthly, sourceSummary = [], sources = [] }) {
   const monthlyChart = monthly.map((m) => ({
     month: m.label,
     Investido: Math.max(0, m.invested),
@@ -41,6 +45,22 @@ export function Dashboard({ monthly }) {
     (value ? new Date(value).toLocaleDateString("pt-BR", { month: "long", year: "numeric" }) : "");
 
   const domain = tsChart.length ? ["dataMin", "dataMax"] : [0, 1];
+
+  const sourceLibrary = Array.isArray(sources) ? sources : [];
+  const sourceChart = Array.isArray(sourceSummary)
+    ? sourceSummary
+        .filter((item) => item.invested > 0)
+        .map((item) => {
+          const visual = resolveSourceVisual(item.name, sourceLibrary);
+          return {
+            name: item.name,
+            value: item.invested,
+            percentage: item.percentage,
+            color: visual.color,
+          };
+        })
+    : [];
+  const hasSourceData = sourceChart.length > 0;
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
@@ -104,6 +124,46 @@ export function Dashboard({ monthly }) {
             </LineChart>
           </ResponsiveContainer>
         </div>
+      </div>
+
+      <div className="rounded-2xl bg-white p-4 shadow lg:col-span-2">
+        <h3 className="mb-4 text-sm font-semibold">Distribuição por fonte de investimento</h3>
+        {hasSourceData ? (
+          <div className="flex flex-col gap-6 md:flex-row md:items-center">
+            <div className="h-64 w-full md:w-1/2">
+              <ResponsiveContainer width="100%" height="100%">
+                <PieChart>
+                  <Tooltip formatter={(value) => fmtBRL(value)} />
+                  <Pie data={sourceChart} dataKey="value" nameKey="name" innerRadius={60} outerRadius={100} paddingAngle={3}>
+                    {sourceChart.map((entry) => (
+                      <Cell key={entry.name} fill={entry.color} />
+                    ))}
+                  </Pie>
+                </PieChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="flex-1">
+              <ul className="space-y-2 text-sm">
+                {sourceChart.map((entry) => (
+                  <li key={entry.name} className="flex items-center justify-between gap-4 rounded-lg bg-slate-50 px-3 py-2">
+                    <span className="flex items-center gap-2 font-medium text-slate-700">
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: entry.color }} aria-hidden="true" />
+                      {entry.name}
+                    </span>
+                    <span className="text-right">
+                      <span className="block text-sm font-semibold text-slate-900">{fmtBRL(entry.value)}</span>
+                      <span className="block text-xs text-slate-500">{entry.percentage}% do total</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
+            Adicione lançamentos com fonte para visualizar esta distribuição.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Entrada.jsx
+++ b/src/components/Entrada.jsx
@@ -1,8 +1,10 @@
 import { createDraftEntry } from "../utils/entries.js";
 import { Field } from "./Field.jsx";
 
-export function Entrada({ drafts, setDrafts, onSubmit, banks }) {
+export function Entrada({ drafts, setDrafts, onSubmit, banks, sources }) {
   const bankOptionsId = "bank-options";
+  const sourceOptionsId = "source-options";
+  const sourceLibrary = Array.isArray(sources) ? sources : [];
 
   function updateRow(id, name, value) {
     setDrafts((prev) =>
@@ -66,6 +68,12 @@ export function Entrada({ drafts, setDrafts, onSubmit, banks }) {
         ))}
       </datalist>
 
+      <datalist id={sourceOptionsId}>
+        {sourceLibrary.map((source) => (
+          <option key={source.name} value={source.name} />
+        ))}
+      </datalist>
+
       <div className="space-y-4">
         {drafts.map((row, index) => (
           <div key={row.id} className="space-y-3 rounded-xl border border-slate-200 p-4">
@@ -116,6 +124,17 @@ export function Entrada({ drafts, setDrafts, onSubmit, banks }) {
                   value={row.bank}
                   disabled={row.locked}
                   onChange={(e) => updateRow(row.id, "bank", e.target.value)}
+                  className="w-full rounded-xl border border-slate-200 px-3 py-2 outline-none focus:ring-2 focus:ring-slate-400 disabled:bg-slate-100"
+                />
+              </Field>
+              <Field className="min-w-[12rem] flex-1" label="Fonte de investimento">
+                <input
+                  type="text"
+                  list={sourceOptionsId}
+                  placeholder="ex.: Salário"
+                  value={row.source}
+                  disabled={row.locked}
+                  onChange={(e) => updateRow(row.id, "source", e.target.value)}
                   className="w-full rounded-xl border border-slate-200 px-3 py-2 outline-none focus:ring-2 focus:ring-slate-400 disabled:bg-slate-100"
                 />
               </Field>

--- a/src/components/Historico.jsx
+++ b/src/components/Historico.jsx
@@ -1,13 +1,15 @@
 import { useMemo, useState } from "react";
 import { resolveBankVisual } from "../config/banks.js";
+import { resolveSourceVisual } from "../config/sources.js";
 import { fmtBRL, fmtPct, monthLabel, toNumber, yyyymm } from "../utils/formatters.js";
 import { Td, Th } from "./TableCells.jsx";
 
-export function Historico({ entries, computedEntries, setEntries, banks }) {
+export function Historico({ entries, computedEntries, setEntries, banks, sources }) {
   const [q, setQ] = useState("");
   const [editingId, setEditingId] = useState(null);
   const [draft, setDraft] = useState(null);
   const [collapsed, setCollapsed] = useState(false);
+  const sourceOptionsId = "source-library";
 
   const baseLookup = useMemo(() => new Map(entries.map((entry) => [entry.id, entry])), [entries]);
 
@@ -71,6 +73,7 @@ export function Historico({ entries, computedEntries, setEntries, banks }) {
     setEditingId(id);
     setDraft({
       bank: original.bank ?? "",
+      source: original.source ?? "",
       date: original.date ? original.date.slice(0, 10) : "",
       inAccount: original.inAccount ?? 0,
       invested: original.invested ?? 0,
@@ -95,6 +98,7 @@ export function Historico({ entries, computedEntries, setEntries, banks }) {
         return {
           ...item,
           bank: draft.bank,
+          source: draft.source?.trim() || "",
           date: draft.date,
           inAccount: toNumber(draft.inAccount),
           invested: toNumber(draft.invested),
@@ -136,6 +140,12 @@ export function Historico({ entries, computedEntries, setEntries, banks }) {
         </div>
       )}
 
+      <datalist id={sourceOptionsId}>
+        {(Array.isArray(sources) ? sources : []).map((source) => (
+          <option key={source.name} value={source.name} />
+        ))}
+      </datalist>
+
       <div className="space-y-6">
         {groups.map((group) => {
           const totals = totalizer(group.items);
@@ -172,6 +182,8 @@ export function Historico({ entries, computedEntries, setEntries, banks }) {
                   onSaveEdit={saveEdit}
                   onRemove={removeEntry}
                   banks={banks}
+                  sources={sources}
+                  sourceOptionsId={sourceOptionsId}
                 />
               )}
             </div>
@@ -182,7 +194,8 @@ export function Historico({ entries, computedEntries, setEntries, banks }) {
   );
 }
 
-function DetailedTable({ items, editingId, draft, onStartEdit, onUpdateDraft, onCancelEdit, onSaveEdit, onRemove, banks }) {
+function DetailedTable({ items, editingId, draft, onStartEdit, onUpdateDraft, onCancelEdit, onSaveEdit, onRemove, banks, sources, sourceOptionsId = "source-library" }) {
+  const library = Array.isArray(sources) ? sources : [];
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full divide-y divide-slate-100 text-sm">
@@ -190,6 +203,7 @@ function DetailedTable({ items, editingId, draft, onStartEdit, onUpdateDraft, on
           <tr>
             <Th>Data</Th>
             <Th>Banco</Th>
+            <Th>Fonte</Th>
             <Th className="text-right">Valor na Conta</Th>
             <Th className="text-right">Valor em Investimentos</Th>
             <Th className="text-right">Entrada/Saída</Th>
@@ -218,18 +232,31 @@ function DetailedTable({ items, editingId, draft, onStartEdit, onUpdateDraft, on
                       new Date(entry.date).toLocaleDateString("pt-BR")
                     )}
                   </Td>
-                  <Td>
-                    {isEditing ? (
-                      <input
-                        type="text"
-                        value={draft?.bank ?? ""}
-                        onChange={(e) => onUpdateDraft("bank", e.target.value)}
-                        className="w-full rounded-lg border border-slate-200 px-2 py-1 text-sm focus:border-slate-400 focus:outline-none"
-                      />
-                    ) : (
-                      <BankBadge name={entry.bank} banks={banks} />
-                    )}
-                  </Td>
+              <Td>
+                {isEditing ? (
+                  <input
+                    type="text"
+                    value={draft?.bank ?? ""}
+                    onChange={(e) => onUpdateDraft("bank", e.target.value)}
+                    className="w-full rounded-lg border border-slate-200 px-2 py-1 text-sm focus:border-slate-400 focus:outline-none"
+                  />
+                ) : (
+                  <BankBadge name={entry.bank} banks={banks} />
+                )}
+              </Td>
+              <Td>
+                {isEditing ? (
+                  <input
+                    type="text"
+                    list={sourceOptionsId}
+                    value={draft?.source ?? ""}
+                    onChange={(e) => onUpdateDraft("source", e.target.value)}
+                    className="w-full rounded-lg border border-slate-200 px-2 py-1 text-sm focus:border-slate-400 focus:outline-none"
+                  />
+                ) : (
+                  <SourceBadge name={entry.source} sources={library} />
+                )}
+              </Td>
                   <Td align="right">
                     {isEditing ? (
                       <input
@@ -391,6 +418,25 @@ function toneClass(value) {
 
 function BankBadge({ name, banks }) {
   const visual = resolveBankVisual(name, banks);
+  return (
+    <span className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
+      <span
+        className="h-2.5 w-2.5 rounded-full"
+        style={{ backgroundColor: visual.color }}
+        aria-hidden="true"
+      ></span>
+      <span className="text-base" aria-hidden="true">
+        {visual.icon}
+      </span>
+      <span>{name}</span>
+    </span>
+  );
+}
+
+function SourceBadge({ name, sources }) {
+  if (!name) return <span className="text-sm text-slate-500">—</span>;
+  const library = Array.isArray(sources) ? sources : [];
+  const visual = resolveSourceVisual(name, library);
   return (
     <span className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
       <span

--- a/src/components/KPICard.jsx
+++ b/src/components/KPICard.jsx
@@ -1,16 +1,38 @@
+import { fmtBRL } from "../utils/formatters.js";
+
 const tones = {
   neutral: "text-slate-900",
   positive: "text-emerald-600",
   negative: "text-red-600",
 };
 
-export function KPICard({ title, value, secondaryValue, subtitle, tone = "neutral" }) {
+export function KPICard({ title, value, secondaryValue, subtitle, tone = "neutral", hoverDetails = [] }) {
   const toneClass = tones[tone] ?? tones.neutral;
+  const details = Array.isArray(hoverDetails) ? hoverDetails : [];
+  const hasHoverDetails = details.length > 0;
+
   return (
-    <div className="rounded-xl bg-white p-3 shadow-sm">
+    <div className="group rounded-xl bg-white p-3 shadow-sm" title={hasHoverDetails ? "Passe o mouse para ver detalhes" : undefined}>
       <div className="text-[0.65rem] uppercase tracking-wide text-slate-500">{title}</div>
-      <div className={`mt-1 text-lg font-semibold ${toneClass}`}>{value}</div>
-      {secondaryValue && <div className={`text-xs font-semibold ${toneClass}`}>{secondaryValue}</div>}
+      <div className={`mt-1 text-lg font-semibold ${toneClass} ${hasHoverDetails ? "group-hover:hidden" : ""}`}>{value}</div>
+      {secondaryValue && (
+        <div className={`text-xs font-semibold ${toneClass} ${hasHoverDetails ? "group-hover:hidden" : ""}`}>{secondaryValue}</div>
+      )}
+      {hasHoverDetails && (
+        <div className="hidden group-hover:block">
+          <ul className="mt-2 space-y-1 text-xs">
+            {details.map((detail) => (
+              <li key={detail.name} className="flex items-center justify-between text-slate-600">
+                <span className="font-medium text-slate-700">{detail.name}</span>
+                <span className="font-semibold text-slate-900">
+                  {fmtBRL(detail.invested ?? detail.total ?? 0)}
+                  {detail.percentage != null ? ` (${detail.percentage}%)` : ""}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       {subtitle && <div className="mt-1 text-[0.7rem] text-slate-500">{subtitle}</div>}
     </div>
   );

--- a/src/components/PersonalInfoModal.jsx
+++ b/src/components/PersonalInfoModal.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+const FIELDS = [
+  { name: "fullName", label: "Nome completo" },
+  { name: "email", label: "E-mail" },
+  { name: "document", label: "Documento" },
+  { name: "phone", label: "Telefone" },
+];
+
+export function PersonalInfoModal({ open, onClose, initialValue, onSave }) {
+  const [form, setForm] = useState(initialValue || {});
+
+  useEffect(() => {
+    setForm(initialValue || {});
+  }, [initialValue, open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    function handleKey(event) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  function handleChange(name, value) {
+    setForm((prev) => ({ ...prev, [name]: value }));
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    onSave(form);
+    onClose();
+  }
+
+  const modal = (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div
+        className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="personal-info-title"
+      >
+        <h3 id="personal-info-title" className="text-lg font-semibold text-slate-900">
+          Informações pessoais
+        </h3>
+        <p className="mt-1 text-sm text-slate-500">
+          Esses dados aparecerão no relatório em PDF e no arquivo exportado.
+        </p>
+
+        <form className="mt-4 space-y-4" onSubmit={handleSubmit}>
+          {FIELDS.map((field) => (
+            <div key={field.name}>
+              <label className="block text-sm font-medium text-slate-700" htmlFor={field.name}>
+                {field.label}
+              </label>
+              <input
+                id={field.name}
+                name={field.name}
+                value={form[field.name] ?? ""}
+                onChange={(event) => handleChange(field.name, event.target.value)}
+                type="text"
+                className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-slate-400"
+              />
+            </div>
+          ))}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800"
+            >
+              Salvar informações
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/src/components/Tab.jsx
+++ b/src/components/Tab.jsx
@@ -1,35 +1,25 @@
-import { Tab } from '@headlessui/react'
-
-function classNames(...classes) {
-  return classes.filter(Boolean).join(' ')
-}
-
 export function Tabs({ tabs, activeTab, onChange }) {
   return (
-    <div className="w-full max-w-3xl mb-6">
-      <Tab.Group selectedIndex={tabs.findIndex(t => t.key === activeTab)} onChange={(index) => onChange(tabs[index].key)}>
-        <Tab.List className="flex space-x-1 rounded-xl bg-blue-900/10 p-1">
-          {tabs.map((tab) => (
-            <Tab
+    <div className="mb-6 w-full max-w-3xl">
+      <div className="flex flex-wrap gap-2 rounded-xl bg-blue-900/10 p-1">
+        {tabs.map((tab) => {
+          const isActive = tab.key === activeTab;
+          return (
+            <button
               key={tab.key}
-              className={({ selected }) =>
-                classNames(
-                  'w-full rounded-lg py-2.5 text-sm font-medium leading-5',
-                  'ring-white ring-opacity-60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2',
-                  selected
-                    ? 'bg-white shadow text-blue-700'
-                    : 'text-blue-700 hover:bg-white/[0.12] hover:text-blue-800'
-                )
-              }
+              type="button"
+              onClick={() => onChange(tab.key)}
+              className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-blue-400 ${
+                isActive ? "bg-white text-blue-700 shadow" : "text-blue-700 hover:bg-white/40"
+              }`}
+              aria-pressed={isActive}
             >
-              <div className="flex items-center justify-center gap-2">
-                {tab.icon}
-                {tab.label}
-              </div>
-            </Tab>
-          ))}
-        </Tab.List>
-      </Tab.Group>
+              {tab.icon}
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
     </div>
-  )
+  );
 }

--- a/src/components/icons.jsx
+++ b/src/components/icons.jsx
@@ -1,0 +1,109 @@
+function Icon({ children, ...props }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function ArrowDownTrayIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M12 3v12" />
+      <path d="M7 11l5 5 5-5" />
+      <path d="M4 18h16" />
+    </Icon>
+  );
+}
+
+export function ArrowUpTrayIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M12 21V9" />
+      <path d="M7 13l5-5 5 5" />
+      <path d="M4 6h16" />
+    </Icon>
+  );
+}
+
+export function DocumentIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M7 3h7l5 5v13H7z" />
+      <path d="M14 3v5h5" />
+    </Icon>
+  );
+}
+
+export function TrashIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M4 7h16" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+      <path d="M6 7l1 12h10l1-12" />
+      <path d="M9 7V5h6v2" />
+    </Icon>
+  );
+}
+
+export function ChartBarIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M4 20h16" />
+      <path d="M8 20V10" />
+      <path d="M12 20V4" />
+      <path d="M16 20v-7" />
+    </Icon>
+  );
+}
+
+export function TableCellsIcon(props) {
+  return (
+    <Icon {...props}>
+      <rect x="4" y="5" width="16" height="14" rx="1" />
+      <path d="M4 11h16" />
+      <path d="M10 5v14" />
+      <path d="M14 5v14" />
+    </Icon>
+  );
+}
+
+export function PlusIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </Icon>
+  );
+}
+
+export function DocumentArrowDownIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M7 3h7l5 5v13H7z" />
+      <path d="M14 3v5h5" />
+      <path d="M12 11v6" />
+      <path d="M9.5 15.5L12 18l2.5-2.5" />
+    </Icon>
+  );
+}
+
+export function UserCircleIcon(props) {
+  return (
+    <Icon {...props}>
+      <circle cx="12" cy="9" r="3.5" />
+      <path d="M5.5 19a6.5 6.5 0 0 1 13 0" />
+      <circle cx="12" cy="12" r="9" />
+    </Icon>
+  );
+}

--- a/src/config/sources.js
+++ b/src/config/sources.js
@@ -1,0 +1,32 @@
+export const DEFAULT_SOURCES = [
+  { name: "Salário", color: "#0EA5E9", icon: "💼" },
+  { name: "Freelance", color: "#6366F1", icon: "🧑‍💻" },
+  { name: "Dividendos", color: "#22C55E", icon: "💰" },
+  { name: "Renda Fixa", color: "#F59E0B", icon: "📈" },
+];
+
+export function stringToSourceColor(input = "") {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = input.charCodeAt(i) + ((hash << 5) - hash);
+    hash |= 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue} 65% 55%)`;
+}
+
+export function resolveSourceVisual(sourceName = "", library = DEFAULT_SOURCES) {
+  const lower = sourceName.toLowerCase();
+  const preset = library.find((source) => source.name.toLowerCase() === lower);
+  if (preset) return preset;
+  return { name: sourceName, color: stringToSourceColor(sourceName), icon: "📊" };
+}
+
+export function ensureSourceInLibrary(sourceName, library = DEFAULT_SOURCES) {
+  if (!sourceName) return library;
+  const lower = sourceName.toLowerCase();
+  const exists = library.some((source) => source.name.toLowerCase() === lower);
+  if (exists) return library;
+  const nextSource = resolveSourceVisual(sourceName, []);
+  return [...library, nextSource];
+}

--- a/src/data/demoEntries.js
+++ b/src/data/demoEntries.js
@@ -1,7 +1,9 @@
 import { DEFAULT_BANKS } from "../config/banks.js";
+import { DEFAULT_SOURCES } from "../config/sources.js";
 
 export const emptyEntry = {
   bank: "",
+  source: "",
   date: "",
   inAccount: 0,
   invested: 0,
@@ -9,11 +11,13 @@ export const emptyEntry = {
 };
 
 export const demoBanks = DEFAULT_BANKS.map((bank) => ({ ...bank }));
+export const demoSources = DEFAULT_SOURCES.map((source) => ({ ...source }));
 
 export const demoEntries = [
   {
     id: "demo-2025-08-01-nubank-caixinhas",
     bank: "Nubank Caixinhas",
+    source: "Salário",
     date: "2025-08-01",
     inAccount: 0,
     invested: 40000,
@@ -22,6 +26,7 @@ export const demoEntries = [
   {
     id: "demo-2025-09-02-nubank-caixinhas",
     bank: "Nubank Caixinhas",
+    source: "Salário",
     date: "2025-09-02",
     inAccount: 0,
     invested: 62240.39,
@@ -30,6 +35,7 @@ export const demoEntries = [
   {
     id: "demo-2025-08-01-nubank-investimentos",
     bank: "Nubank Investimentos",
+    source: "Dividendos",
     date: "2025-08-01",
     inAccount: 0,
     invested: 47000,
@@ -38,6 +44,7 @@ export const demoEntries = [
   {
     id: "demo-2025-09-02-nubank-investimentos",
     bank: "Nubank Investimentos",
+    source: "Dividendos",
     date: "2025-09-02",
     inAccount: 0,
     invested: 47600.48,
@@ -46,6 +53,7 @@ export const demoEntries = [
   {
     id: "demo-2025-08-01-xp",
     bank: "XP",
+    source: "Renda Fixa",
     date: "2025-08-01",
     inAccount: 150,
     invested: 27500,
@@ -54,6 +62,7 @@ export const demoEntries = [
   {
     id: "demo-2025-09-02-xp",
     bank: "XP",
+    source: "Renda Fixa",
     date: "2025-09-02",
     inAccount: 216.32,
     invested: 28063.77,
@@ -62,6 +71,7 @@ export const demoEntries = [
   {
     id: "demo-2025-08-01-inter",
     bank: "Inter",
+    source: "Freelance",
     date: "2025-08-01",
     inAccount: -200,
     invested: 22000,
@@ -70,6 +80,7 @@ export const demoEntries = [
   {
     id: "demo-2025-09-02-inter",
     bank: "Inter",
+    source: "Freelance",
     date: "2025-09-02",
     inAccount: -400,
     invested: 23351.03,
@@ -78,6 +89,7 @@ export const demoEntries = [
   {
     id: "demo-2025-08-01-nubank-cripto",
     bank: "Nubank Cripto",
+    source: "Dividendos",
     date: "2025-08-01",
     inAccount: 0,
     invested: 9000,
@@ -86,6 +98,7 @@ export const demoEntries = [
   {
     id: "demo-2025-09-02-nubank-cripto",
     bank: "Nubank Cripto",
+    source: "Dividendos",
     date: "2025-09-02",
     inAccount: 0,
     invested: 1108.65,
@@ -94,6 +107,7 @@ export const demoEntries = [
   {
     id: "demo-2025-08-01-binance",
     bank: "Binance",
+    source: "Dividendos",
     date: "2025-08-01",
     inAccount: 0,
     invested: 2000,
@@ -102,6 +116,7 @@ export const demoEntries = [
   {
     id: "demo-2025-09-02-binance",
     bank: "Binance",
+    source: "Dividendos",
     date: "2025-09-02",
     inAccount: 0,
     invested: 2181,

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,0 +1,141 @@
+import { fmtBRL } from "./formatters.js";
+
+const LINE_HEIGHT = 16;
+const TOP_MARGIN = 800;
+const MAX_ENTRY_LINES = 25;
+
+export function createPdfReport({ personalInfo = {}, totals = {}, sources = [], entries = [], exportedAt = new Date() }) {
+  const lines = [];
+  const dateLabel = new Date(exportedAt).toLocaleString("pt-BR");
+
+  lines.push("Relatório de Investimentos");
+  lines.push(`Gerado em ${dateLabel}`);
+  lines.push("");
+
+  const personalEntries = Object.entries(personalInfo || {}).filter(([, value]) => value);
+  if (personalEntries.length) {
+    lines.push("Informações pessoais:");
+    personalEntries.forEach(([key, value]) => {
+      lines.push(`- ${toLabel(key)}: ${value}`);
+    });
+    lines.push("");
+  }
+
+  lines.push("Resumo:");
+  lines.push(`- Total investido: ${fmtBRL(totals.total_invested ?? 0)}`);
+  lines.push(`- Total em conta: ${fmtBRL(totals.total_in_account ?? 0)}`);
+  lines.push(`- Entradas/Saídas: ${fmtBRL(totals.total_input ?? 0)}`);
+  lines.push(`- Rendimento acumulado: ${fmtBRL(totals.total_yield_value ?? 0)}`);
+  lines.push("");
+
+  const normalizedSources = Array.isArray(sources)
+    ? sources.filter((source) => (source.total ?? source.invested ?? 0) !== 0)
+    : [];
+  if (normalizedSources.length) {
+    lines.push("Fontes de investimento:");
+    normalizedSources.forEach((source) => {
+      const total = source.total ?? source.invested ?? 0;
+      const percentage = source.percentage != null ? `${source.percentage}%` : "";
+      lines.push(`- ${source.name}: ${fmtBRL(total)} ${percentage}`.trim());
+    });
+    lines.push("");
+  }
+
+  if (entries.length) {
+    lines.push("Lançamentos:");
+    const limited = entries.slice(0, MAX_ENTRY_LINES);
+    limited.forEach((entry) => {
+      const date = entry.date ? new Date(entry.date).toLocaleDateString("pt-BR") : "";
+      const bank = entry.bank || "";
+      const source = entry.source || "–";
+      lines.push(
+        `- ${date} | ${bank} | Fonte: ${source} | Investido: ${fmtBRL(entry.invested ?? 0)} | Em conta: ${fmtBRL(entry.inAccount ?? 0)} | Fluxo: ${fmtBRL(entry.cashFlow ?? 0)}`
+      );
+    });
+    if (entries.length > limited.length) {
+      lines.push(`- ... e mais ${entries.length - limited.length} lançamentos.`);
+    }
+  } else {
+    lines.push("Sem lançamentos registrados até o momento.");
+  }
+
+  const pdfContent = buildPdf(lines);
+  const blob = new Blob([pdfContent], { type: "application/pdf" });
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = `relatorio-investimentos-${new Date().toISOString().slice(0, 10)}.pdf`;
+  document.body.appendChild(link);
+  link.click();
+  const url = link.href;
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function buildPdf(lines) {
+  const encoder = new TextEncoder();
+  const textStream = buildTextStream(lines);
+
+  const header = "%PDF-1.4\n";
+  const obj1 = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+  const obj2 = "2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n";
+  const obj3 =
+    "3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n";
+  const obj4 = `4 0 obj\n<< /Length ${encoder.encode(textStream).length} >>\nstream\n${textStream}\nendstream\nendobj\n`;
+  const obj5 = "5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n";
+
+  const objects = [obj1, obj2, obj3, obj4, obj5];
+  const offsets = [0];
+  let position = encoder.encode(header).length;
+
+  objects.forEach((object) => {
+    offsets.push(position);
+    position += encoder.encode(object).length;
+  });
+
+  const xrefPosition = position;
+  let xref = `xref\n0 ${offsets.length}\n`;
+  xref += "0000000000 65535 f \n";
+  for (let i = 1; i < offsets.length; i += 1) {
+    xref += `${String(offsets[i]).padStart(10, "0")} 00000 n \n`;
+  }
+
+  const trailer = `trailer\n<< /Size ${offsets.length} /Root 1 0 R >>\nstartxref\n${xrefPosition}\n%%EOF`;
+
+  return [header, ...objects, xref, trailer].join("");
+}
+
+function buildTextStream(lines) {
+  const safeLines = Array.isArray(lines) ? lines : [];
+  const commands = ["BT", "/F1 12 Tf", `${LINE_HEIGHT} TL`, `72 ${TOP_MARGIN} Td`];
+  safeLines.forEach((line, index) => {
+    const text = escapePdfText(line || " ");
+    if (index === 0) {
+      commands.push(`(${text}) Tj`);
+    } else {
+      commands.push("T*");
+      if (line !== "") {
+        commands.push(`(${text}) Tj`);
+      }
+    }
+  });
+  commands.push("ET");
+  return commands.join("\n");
+}
+
+function escapePdfText(text) {
+  return String(text)
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/\r?\n/g, " ");
+}
+
+function toLabel(key) {
+  const map = {
+    fullName: "Nome completo",
+    email: "E-mail",
+    document: "Documento",
+    phone: "Telefone",
+  };
+  return map[key] || key;
+}


### PR DESCRIPTION
## Summary
- add investment source metadata, persist it with entries, and seed demo/template data
- redesign the dashboard/header to expose source-aware KPIs, a distribution chart, and a personal data modal while replacing external icon/tab dependencies
- implement a client-side PDF report generator and include personal information in exports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e16e3a472c8320b9f9091259f6f1c8