### PR TITLE
Run project tests and fix failures

### DIFF
--- a/src/components/Projecoes.jsx
+++ b/src/components/Projecoes.jsx
@@ -100,7 +100,7 @@ export function Projecoes({ timeline = [], defaults = {} }) {
     inflationPct: decimalToPercent(safeDefaults.inflationRate ?? 0.04),
     contributionGrowthPct: decimalToPercent(safeDefaults.contributionGrowth ?? 0.02),
     goalAmount: Math.max(
-      safeDefaults.goalAmount ?? Math.max(safeDefaults.initialBalance ?? 0, 0) * 2 || (trailingStats.lastMonth.invested || 500) * 200,
+      safeDefaults.goalAmount ?? (Math.max(safeDefaults.initialBalance ?? 0, 0) * 2 || (trailingStats.lastMonth.invested || 500) * 200),
       0
     ),
     withdrawalRatePct: decimalToPercent(0.04),


### PR DESCRIPTION
Fix syntax error in `Projecoes.jsx` to resolve ambiguous operator precedence and allow tests to pass.

The `Math.max` expression combined `||` and `??` operators without proper grouping, leading to a build error and preventing tests from running successfully. Encapsulating the problematic part in parentheses clarifies the intended order of operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e4f7683-099f-4a91-a797-fee81e90d44e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e4f7683-099f-4a91-a797-fee81e90d44e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

