### PR TITLE
Fix merge conflicts and test errors

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -40,47 +40,6 @@ export function Dashboard({ monthly, sourceSummary = [], sources = [] }) {
 
   const domain = safeMonthly.length ? ["dataMin", "dataMax"] : [0, 1];
 
-  // Preparar dados do fluxo por fonte
-  const flowChartBySource = safeMonthly.map((m) => {
-    const row = { ts: m.midDateValue, label: m.label };
-    const monthlySources = new Map(
-      (Array.isArray(m.sources) ? m.sources : []).map((source) => [source.name, source.invested])
-    );
-    
-    // Calcular fluxo líquido por fonte (entrada - saída)
-    uniqueSourceNames.forEach((name) => {
-      const sourceValue = monthlySources.get(name) ?? 0;
-      row[name] = sourceValue; // Valor absoluto do fluxo por fonte
-    });
-    
-    return row;
-  });
-  const hasFlowData = flowChartBySource.some((row) => 
-    uniqueSourceNames.some(name => row[name] !== 0)
-  );
-
-  // Preparar dados do rendimento mensal por fonte
-  const yieldChartBySource = safeMonthly.map((m) => {
-    const row = { ts: m.midDateValue, label: m.label };
-    const monthlySources = new Map(
-      (Array.isArray(m.sources) ? m.sources : []).map((source) => [source.name, source.invested])
-    );
-    
-    // Calcular rendimento mensal por fonte (assumindo que o yieldValue é proporcional ao investido)
-    const totalInvested = m.invested || 1; // Evitar divisão por zero
-    const yieldPct = m.yieldPct || 0;
-    
-    uniqueSourceNames.forEach((name) => {
-      const sourceInvested = monthlySources.get(name) ?? 0;
-      const sourceYield = sourceInvested * yieldPct;
-      row[name] = sourceYield;
-    });
-    
-    return row;
-  });
-  const hasYieldData = yieldChartBySource.some((row) => 
-    uniqueSourceNames.some(name => row[name] !== 0)
-  );
   const formatShortK = (value) => {
     const numeric = Number(value) || 0;
     const abs = Math.abs(numeric);
@@ -180,7 +139,7 @@ export function Dashboard({ monthly, sourceSummary = [], sources = [] }) {
         <div className="h-72">
           {hasFlowData ? (
             <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={flowChartBySource}>
+              <AreaChart data={perSourceNet}>
                 <defs>
                   {uniqueSourceNames.map((name, index) => {
                     const gradientId = `flow-source-${index}`;
@@ -224,7 +183,7 @@ export function Dashboard({ monthly, sourceSummary = [], sources = [] }) {
         <div className="h-72">
           {hasYieldData ? (
             <ResponsiveContainer width="100%" height="100%">
-              <AreaChart data={yieldChartBySource}>
+              <AreaChart data={yieldChart}>
                 <defs>
                   {uniqueSourceNames.map((name, index) => {
                     const gradientId = `yield-source-${index}`;


### PR DESCRIPTION
Resolve merge conflicts by removing duplicate variable declarations and updating chart data sources.

The merge conflicts resulted in `hasFlowData` and `hasYieldData` being declared twice, causing compilation errors. This PR removes the duplicate declarations, removes unused chart data variables, and updates the charts to use the correct data sources (`perSourceNet` for flow and `yieldChart` for yield), making all tests pass.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d5c1e8f-00ee-4bc6-9b1f-9c5eb5e93a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d5c1e8f-00ee-4bc6-9b1f-9c5eb5e93a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

