### PR TITLE
Fix projection component tests

### DIFF
--- a/src/components/Projecoes.jsx
+++ b/src/components/Projecoes.jsx
@@ -439,6 +439,11 @@ export function Projecoes({ timeline = [], defaults = {} }) {
                 }
                 className="w-full rounded-lg border border-slate-200 px-2 py-1 text-xs shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
               />
+              {trailingStats.lastMonth.yieldPct !== null && (
+                <span className="text-xs text-slate-500">
+                  Último mês: {fmtPct(trailingStats.lastMonth.yieldPct)}
+                </span>
+              )}
               {trailingStats.monthsConsidered > 0 && (
                 <span className="text-xs text-slate-500">
                   Média últimos {trailingStats.monthsConsidered} meses:{" "}

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,11 @@
 import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+// Ensure React Testing Library cleans up between tests to avoid DOM leakage
+afterEach(() => {
+  cleanup();
+});
 // Polyfills needed by pdfjs in jsdom
 if (typeof window !== "undefined") {
   // Basic DOMMatrix polyfill for tests


### PR DESCRIPTION
Add "Último mês" display to the projection component and ensure React Testing Library cleanup to fix failing tests.

The tests were failing because the "Último mês" text was not present in the DOM, and multiple "Rentabilidade mensal" elements were found, likely due to DOM leakage between tests. Adding the "Último mês" span and implementing `cleanup()` after each test resolves these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-015943cc-4fcc-40c4-85a9-714b34b28d41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-015943cc-4fcc-40c4-85a9-714b34b28d41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

