### PR TITLE
feat: add pdf report generation for investments and expenses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
+        "@react-pdf/renderer": "^3.4.5",
         "html2pdf.js": "^0.12.1",
         "papaparse": "^5.5.3",
         "pdfjs-dist": "^5.4.149",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
+    "@react-pdf/renderer": "^3.4.5",
     "html2pdf.js": "^0.12.1",
     "papaparse": "^5.5.3",
     "pdfjs-dist": "^5.4.149",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -582,6 +582,13 @@ export default function App() {
                   Importar
                 </ActionButton>
                 <Link
+                  to="/investimentos/relatorio"
+                  className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+                >
+                  <DocumentArrowDownIcon className="h-5 w-5" />
+                  Relatório PDF
+                </Link>
+                <Link
                   to="/investimentos/configuracoes"
                   className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
                 >

--- a/src/expenses/ExpensesApp.jsx
+++ b/src/expenses/ExpensesApp.jsx
@@ -19,6 +19,7 @@ import {
   PlusIcon,
   TableCellsIcon,
   ChartBarIcon,
+  DocumentArrowDownIcon,
   SettingsIcon,
 } from "../components/icons.jsx";
 import { CalculatorIcon } from "@heroicons/react/24/outline";
@@ -423,6 +424,13 @@ export default function ExpensesApp() {
                 >
                   Importar
                 </ActionButton>
+                <Link
+                  to="/gastos/relatorio"
+                  className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+                >
+                  <DocumentArrowDownIcon className="h-5 w-5" />
+                  Relatório PDF
+                </Link>
                 <Link
                   to="/gastos/configuracoes"
                   className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"

--- a/src/expenses/pages/ExpensesReport.jsx
+++ b/src/expenses/pages/ExpensesReport.jsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { usePDF } from "@react-pdf/renderer";
+import { DocumentArrowDownIcon } from "../../components/icons.jsx";
+import { useLocalStorageState } from "../../hooks/useLocalStorageState.js";
+import { buildReportDataset } from "../../utils/reporting.js";
+import { monthLabel, toNumber } from "../../utils/formatters.js";
+import { EXPENSES_LS_KEY, EXPENSES_STORAGE_SEED, ensureExpensesDefaults } from "../config/storage.js";
+import { computeDerivedExpenses, computeTotals } from "../utils/expenses.js";
+import { createExpensesReportDocument } from "../../utils/pdf.js";
+
+function sumExpensesMonthly(expenses = []) {
+  return expenses.reduce(
+    (acc, expense) => {
+      acc.total += Math.abs(toNumber(expense.value));
+      return acc;
+    },
+    { total: 0 }
+  );
+}
+
+function buildBreakdown(expenses = [], key) {
+  const map = new Map();
+  expenses.forEach((expense) => {
+    const label = expense[key] || (key === "category" ? "Sem categoria" : "Sem fonte");
+    const current = map.get(label) || 0;
+    map.set(label, current + Math.abs(toNumber(expense.value)));
+  });
+  return Array.from(map.entries())
+    .map(([name, total]) => ({ name, total }))
+    .sort((a, b) => b.total - a.total);
+}
+
+export default function ExpensesReport() {
+  const [generatedAt] = useState(() => new Date());
+  const [storeState] = useLocalStorageState(EXPENSES_LS_KEY, EXPENSES_STORAGE_SEED);
+  const store = ensureExpensesDefaults(storeState);
+  const derivedExpenses = useMemo(() => computeDerivedExpenses(store.expenses || []), [store.expenses]);
+
+  const report = useMemo(
+    () =>
+      buildReportDataset({
+        items: derivedExpenses,
+        personalInfo: store.personalInfo,
+        notes: "",
+        exportedAt: generatedAt,
+        computeMonthlySummary: (items) => sumExpensesMonthly(items),
+        computeTotals,
+      }),
+    [derivedExpenses, store.personalInfo, generatedAt]
+  );
+
+  const categoryBreakdown = useMemo(() => buildBreakdown(report.items, "category"), [report.items]);
+  const sourceBreakdown = useMemo(() => buildBreakdown(report.items, "source"), [report.items]);
+
+  const document = useMemo(
+    () =>
+      createExpensesReportDocument({
+        exportedAt: report.exportedAt,
+        personalInfo: report.personalInfo,
+        totals: report.totals,
+        monthlySummaries: report.monthlySummaries,
+        notes: report.notes,
+        expenses: report.items,
+        categoryBreakdown,
+        sourceBreakdown,
+      }),
+    [
+      report.exportedAt,
+      report.personalInfo,
+      report.totals,
+      report.monthlySummaries,
+      report.notes,
+      report.items,
+      categoryBreakdown,
+      sourceBreakdown,
+    ]
+  );
+
+  const { url, loading, error, update } = usePDF({ document });
+  const [pendingOpen, setPendingOpen] = useState(false);
+  const [popupBlocked, setPopupBlocked] = useState(false);
+
+  useEffect(() => {
+    if (typeof update === "function") {
+      update(document);
+    }
+  }, [document, update]);
+
+  useEffect(() => {
+    if (!pendingOpen || loading || !url) return;
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (opened) {
+      opened.focus();
+      setPopupBlocked(false);
+      setPendingOpen(false);
+    } else {
+      setPopupBlocked(true);
+      setPendingOpen(false);
+    }
+  }, [pendingOpen, loading, url]);
+
+  useEffect(() => {
+    if (error) {
+      setPendingOpen(false);
+    }
+  }, [error]);
+
+  const handleOpenPdf = () => {
+    if (loading || !url) {
+      setPendingOpen(true);
+      return;
+    }
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (opened) {
+      opened.focus();
+      setPopupBlocked(false);
+      setPendingOpen(false);
+    } else {
+      setPopupBlocked(true);
+    }
+  };
+
+  const hasPeriod = report.startYm && report.endYm;
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-6 text-slate-800">
+      <div className="mx-auto flex max-w-4xl flex-col gap-6">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900">Relatório PDF de Gastos</h1>
+            <p className="text-sm text-slate-600">
+              Gere um documento consolidado das despesas registradas nos últimos 12 meses.
+            </p>
+            {hasPeriod ? (
+              <p className="text-xs text-slate-500">
+                Intervalo considerado: {monthLabel(report.startYm)} – {monthLabel(report.endYm)}
+              </p>
+            ) : (
+              <p className="text-xs text-slate-500">Cadastre despesas com data para liberar o PDF.</p>
+            )}
+          </div>
+          <Link
+            to="/gastos"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+          >
+            ← Voltar para gastos
+          </Link>
+        </div>
+
+        <div className="rounded-2xl bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-slate-600">
+              O relatório abre em uma nova aba. Caso o navegador bloqueie pop-ups, libere a visualização para continuar.
+            </p>
+            <div>
+              <button
+                type="button"
+                onClick={handleOpenPdf}
+                disabled={loading || report.itemCount === 0}
+                className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <DocumentArrowDownIcon className="h-5 w-5" />
+                {loading ? "Gerando..." : "Relatório PDF"}
+              </button>
+            </div>
+            {popupBlocked && (
+              <p className="text-sm text-amber-600">
+                Não foi possível abrir a nova aba. Desative o bloqueio de pop-ups e tente novamente.
+              </p>
+            )}
+            {error && <p className="text-sm text-red-600">Não foi possível gerar o PDF. Tente novamente em instantes.</p>}
+            {report.itemCount === 0 && (
+              <p className="text-sm text-slate-500">
+                Nenhuma despesa com data registrada nos últimos 12 meses. Adicione novos lançamentos antes de gerar o PDF.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,8 @@ import App from "./App.jsx";
 import ExpensesApp from "./expenses/ExpensesApp.jsx";
 import InvestmentSettings from "./pages/InvestmentSettings.jsx";
 import ExpensesSettings from "./expenses/pages/ExpensesSettings.jsx";
+import InvestmentReport from "./pages/InvestmentReport.jsx";
+import ExpensesReport from "./expenses/pages/ExpensesReport.jsx";
 import ErrorPage from "./components/ErrorPage.jsx";
 import { HomePage } from "./components/HomePage.jsx";
 import "./index.css";
@@ -19,8 +21,10 @@ const router = createBrowserRouter(
         { index: true, element: <HomePage /> },
         { path: "investimentos", element: <App /> },
         { path: "investimentos/configuracoes", element: <InvestmentSettings /> },
+        { path: "investimentos/relatorio", element: <InvestmentReport /> },
         { path: "gastos", element: <ExpensesApp /> },
         { path: "gastos/configuracoes", element: <ExpensesSettings /> },
+        { path: "gastos/relatorio", element: <ExpensesReport /> },
         { path: "gastos/financiamentos", element: <ExpensesApp /> },
         { path: "*", element: <ErrorPage /> },
       ],

--- a/src/pages/InvestmentReport.jsx
+++ b/src/pages/InvestmentReport.jsx
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { usePDF } from "@react-pdf/renderer";
+import { DocumentArrowDownIcon } from "../components/icons.jsx";
+import { useLocalStorageState } from "../hooks/useLocalStorageState.js";
+import { LS_KEY, toNumber, monthLabel } from "../utils/formatters.js";
+import { computeDerivedEntries, computeTotals } from "../utils/entries.js";
+import { createInvestmentReportDocument } from "../utils/pdf.js";
+import { buildReportDataset } from "../utils/reporting.js";
+import { INVESTMENT_STORAGE_SEED, ensureInvestmentDefaults } from "../config/investmentStorage.js";
+
+function sumInvestmentMonthly(items = []) {
+  return items.reduce(
+    (acc, item) => {
+      acc.invested += toNumber(item.invested);
+      acc.inAccount += toNumber(item.inAccount);
+      acc.cashFlow += toNumber(item.cashFlow);
+      if (item.yieldValue !== null && item.yieldValue !== undefined) {
+        acc.yieldValue += toNumber(item.yieldValue);
+      }
+      return acc;
+    },
+    { invested: 0, inAccount: 0, cashFlow: 0, yieldValue: 0 }
+  );
+}
+
+function buildSourceBreakdown(entries = []) {
+  const map = new Map();
+  entries.forEach((entry) => {
+    const key = entry.source || "Sem fonte";
+    const current = map.get(key) || { invested: 0, inAccount: 0 };
+    current.invested += toNumber(entry.invested);
+    current.inAccount += toNumber(entry.inAccount);
+    map.set(key, current);
+  });
+  return Array.from(map.entries())
+    .map(([name, values]) => ({ name, invested: values.invested, inAccount: values.inAccount }))
+    .sort((a, b) => b.invested + b.inAccount - (a.invested + a.inAccount));
+}
+
+export default function InvestmentReport() {
+  const [generatedAt] = useState(() => new Date());
+  const [storeState] = useLocalStorageState(LS_KEY, INVESTMENT_STORAGE_SEED);
+  const store = ensureInvestmentDefaults(storeState);
+  const derivedEntries = useMemo(() => computeDerivedEntries(store.entries || []), [store.entries]);
+
+  const report = useMemo(
+    () =>
+      buildReportDataset({
+        items: derivedEntries,
+        personalInfo: store.personalInfo,
+        notes: store.settings?.reportNotes ?? "",
+        exportedAt: generatedAt,
+        computeMonthlySummary: sumInvestmentMonthly,
+        computeTotals,
+      }),
+    [derivedEntries, store.personalInfo, store.settings?.reportNotes, generatedAt]
+  );
+
+  const sourceBreakdown = useMemo(() => buildSourceBreakdown(report.items), [report.items]);
+
+  const document = useMemo(
+    () =>
+      createInvestmentReportDocument({
+        exportedAt: report.exportedAt,
+        personalInfo: report.personalInfo,
+        totals: report.totals,
+        monthlySummaries: report.monthlySummaries,
+        notes: report.notes,
+        entries: report.items,
+        sourceBreakdown,
+      }),
+    [report.exportedAt, report.personalInfo, report.totals, report.monthlySummaries, report.notes, report.items, sourceBreakdown]
+  );
+
+  const { url, loading, error, update } = usePDF({ document });
+  const [pendingOpen, setPendingOpen] = useState(false);
+  const [popupBlocked, setPopupBlocked] = useState(false);
+
+  useEffect(() => {
+    if (typeof update === "function") {
+      update(document);
+    }
+  }, [document, update]);
+
+  useEffect(() => {
+    if (!pendingOpen || loading || !url) return;
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (opened) {
+      opened.focus();
+      setPopupBlocked(false);
+      setPendingOpen(false);
+    } else {
+      setPopupBlocked(true);
+      setPendingOpen(false);
+    }
+  }, [pendingOpen, loading, url]);
+
+  useEffect(() => {
+    if (error) {
+      setPendingOpen(false);
+    }
+  }, [error]);
+
+  const handleOpenPdf = () => {
+    if (loading || !url) {
+      setPendingOpen(true);
+      return;
+    }
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (opened) {
+      opened.focus();
+      setPopupBlocked(false);
+      setPendingOpen(false);
+    } else {
+      setPopupBlocked(true);
+    }
+  };
+
+  const hasPeriod = report.startYm && report.endYm;
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-6 text-slate-800">
+      <div className="mx-auto flex max-w-4xl flex-col gap-6">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-900">Relatório PDF de Investimentos</h1>
+            <p className="text-sm text-slate-600">
+              Gere um documento com o resumo dos últimos 12 meses para compartilhar ou arquivar.
+            </p>
+            {hasPeriod ? (
+              <p className="text-xs text-slate-500">
+                Intervalo considerado: {monthLabel(report.startYm)} – {monthLabel(report.endYm)}
+              </p>
+            ) : (
+              <p className="text-xs text-slate-500">Adicione lançamentos com data para gerar o PDF.</p>
+            )}
+          </div>
+          <Link
+            to="/investimentos"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
+          >
+            ← Voltar para investimentos
+          </Link>
+        </div>
+
+        <div className="rounded-2xl bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-slate-600">
+              O relatório abre em uma nova aba. Caso o navegador bloqueie pop-ups, permita temporariamente para concluir o
+              download.
+            </p>
+            <div>
+              <button
+                type="button"
+                onClick={handleOpenPdf}
+                disabled={loading || report.itemCount === 0}
+                className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <DocumentArrowDownIcon className="h-5 w-5" />
+                {loading ? "Gerando..." : "Relatório PDF"}
+              </button>
+            </div>
+            {popupBlocked && (
+              <p className="text-sm text-amber-600">
+                Não foi possível abrir a nova aba. Desbloqueie pop-ups para o Financial Monitor e tente novamente.
+              </p>
+            )}
+            {error && <p className="text-sm text-red-600">Não foi possível gerar o PDF. Tente novamente em instantes.</p>}
+            {report.itemCount === 0 && (
+              <p className="text-sm text-slate-500">
+                Nenhum lançamento com data registrada nos últimos 12 meses. Atualize seus dados antes de gerar o PDF.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/utils/reporting.js
+++ b/src/utils/reporting.js
@@ -1,0 +1,109 @@
+import { enumerateMonths, monthLabel, yyyymm } from "./formatters.js";
+
+function sanitizePersonalInfo(personalInfo = {}) {
+  const entries = Object.entries(personalInfo || {}).map(([key, value]) => {
+    if (typeof value === "string") {
+      return [key, value.trim()];
+    }
+    return [key, value];
+  });
+
+  return Object.fromEntries(
+    entries.filter(([, value]) => {
+      if (value === null || value === undefined) return false;
+      if (typeof value === "string") return value.trim().length > 0;
+      if (typeof value === "number") return !Number.isNaN(value);
+      return Boolean(value);
+    })
+  );
+}
+
+function defaultDateSelector(item) {
+  return item?.date;
+}
+
+function toDate(value) {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function computeRange(monthKeys) {
+  if (!monthKeys.length) {
+    return { months: [], startYm: undefined, endYm: undefined };
+  }
+
+  const unique = Array.from(new Set(monthKeys)).sort();
+  const endYm = unique[unique.length - 1];
+  const [year, month] = endYm.split("-").map(Number);
+  const endDate = new Date(year, month - 1, 1);
+  endDate.setHours(0, 0, 0, 0);
+  const startDate = new Date(endDate);
+  startDate.setMonth(startDate.getMonth() - 11);
+  const startYm = yyyymm(startDate);
+  const months = enumerateMonths(startYm, endYm);
+  return { months, startYm, endYm };
+}
+
+export function buildReportDataset({
+  items = [],
+  personalInfo = {},
+  notes = "",
+  exportedAt = new Date(),
+  dateSelector = defaultDateSelector,
+  computeMonthlySummary = () => ({}),
+  computeTotals = () => ({}),
+} = {}) {
+  const validItems = (Array.isArray(items) ? items : []).filter((item) => {
+    const dateValue = dateSelector(item);
+    return Boolean(yyyymm(dateValue));
+  });
+
+  const monthKeys = validItems.map((item) => yyyymm(dateSelector(item))).filter(Boolean);
+  const { months, startYm, endYm } = computeRange(monthKeys);
+  const monthSet = new Set(months);
+
+  const filteredItems = validItems
+    .filter((item) => monthSet.size === 0 || monthSet.has(yyyymm(dateSelector(item))))
+    .sort((a, b) => {
+      const dateA = toDate(dateSelector(a));
+      const dateB = toDate(dateSelector(b));
+      const timeA = dateA ? dateA.getTime() : 0;
+      const timeB = dateB ? dateB.getTime() : 0;
+      return timeB - timeA;
+    });
+
+  const monthlySummaries = months
+    .map((ym) => {
+      const monthItems = filteredItems.filter((item) => yyyymm(dateSelector(item)) === ym);
+      if (!monthItems.length) {
+        return null;
+      }
+      const summary = computeMonthlySummary(monthItems, ym) || {};
+      return {
+        ym,
+        label: monthLabel(ym),
+        items: monthItems,
+        ...summary,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => (a.ym > b.ym ? -1 : a.ym < b.ym ? 1 : 0));
+
+  const totals = computeTotals(filteredItems) || {};
+  const sanitizedInfo = sanitizePersonalInfo(personalInfo);
+  const normalizedNotes = (notes ?? "").toString().trim();
+  const exportDate = toDate(exportedAt) || new Date();
+
+  return {
+    exportedAt: exportDate.toISOString(),
+    items: filteredItems,
+    totals,
+    monthlySummaries,
+    notes: normalizedNotes,
+    personalInfo: sanitizedInfo,
+    startYm,
+    endYm,
+    itemCount: filteredItems.length,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add @react-pdf/renderer and a reusable reporting dataset helper to support PDF generation
- replace the PDF utility with @react-pdf/renderer documents for investments and expenses
- implement dedicated investment and expense report pages/routes with UI fallback messaging and dashboard links

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e3d22aadc08320ba0f6bdf66aeda89